### PR TITLE
Fix GLMakie region colorbar in 2D/3D Plots

### DIFF
--- a/src/makie.jl
+++ b/src/makie.jl
@@ -494,16 +494,18 @@ function makescene_grid(ctx)
     GL = XMakie.GridLayout(ctx[:figure])
     GL[1, 1] = ctx[:scene]
     ncol = length(ctx[:cmap])
-    nbcol = length(ctx[:cmap])
+    nbcol = length(ctx[:bcmap])
     # fontsize=0.5*ctx[:fontsize],ticklabelsize=0.5*ctx[:fontsize]
     if ctx[:colorbar] == :vertical
         GL[1, 2] = XMakie.Colorbar(ctx[:figure];
                                    colormap = XMakie.cgrad(ctx[:cmap]; categorical = true),
-                                   limits = (1, ncol),
+                                   limits = (0.5, ncol+0.5),
+                                   ticks = 1:ncol,
                                    width = 15,)
         GL[1, 3] = XMakie.Colorbar(ctx[:figure];
                                    colormap = XMakie.cgrad(ctx[:bcmap]; categorical = true),
-                                   limits = (1, nbcol),
+                                   limits = (0.5, nbcol+0.5),
+                                   ticks = 1:nbcol,
                                    width = 15,)
     elseif ctx[:colorbar] == :horizontal
         GL[2, 1] = XMakie.Colorbar(ctx[:figure];


### PR DESCRIPTION
This displays the color bars in a GLMakie plot a bit different.

- the correct number of boundary regions is now considered
- the ticks are shifted by `0.5` to appear in the center of the segments
- it is now guaranteed that all integers are displayed.

Before:
![before3d](https://github.com/user-attachments/assets/9769c58c-7e95-4092-a1ca-7b3a85151ab9)
![before2d](https://github.com/user-attachments/assets/c54646f3-bdfb-41d5-877c-1ec0517aa72f)

After:
![after3d](https://github.com/user-attachments/assets/6b21edd9-029e-4d8e-8e54-b3316bb3c493)
![after2d](https://github.com/user-attachments/assets/f247846f-0f02-4439-83f0-5f66c0d0c78a)

Code example
```julia
grid = simplexgrid( 0:1, 0:1, 0:1 )
gridplot!( GridVisualizer(Plotter=GLMakie) , grid)
```