### PR TITLE
GLMakie: Annotate cell/boundary region color bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- `gridplot` with `PyPlot` has now a color bar with annotation `boundary regions`
+- `gridplot` with `GLMakie` and `PyPlot` now annotates the color bars with `boundary regions` and `cell regions`
 
 ## [1.9.0] - 2024-11-25
 

--- a/src/makie.jl
+++ b/src/makie.jl
@@ -538,6 +538,7 @@ function makescene_grid(ctx)
                 limits = (0.5, ncol + 0.5),
                 ticks = 1:ncol,
                 width = 15,
+                label = "cell regions",
             )
             GL[1, 3] = XMakie.Colorbar(
                 ctx[:figure];
@@ -545,6 +546,7 @@ function makescene_grid(ctx)
                 limits = (0.5, nbcol + 0.5),
                 ticks = 1:nbcol,
                 width = 15,
+                label = "boundary regions",
             )
         elseif ctx[:colorbar] == :horizontal
             GL[2, 1] = XMakie.Colorbar(
@@ -553,6 +555,7 @@ function makescene_grid(ctx)
                 limits = (1, ncol),
                 height = 15,
                 vertical = false,
+                label = "cell regions",
             )
             GL[3, 1] = XMakie.Colorbar(
                 ctx[:figure];
@@ -560,6 +563,7 @@ function makescene_grid(ctx)
                 limits = (1, nbcol),
                 height = 15,
                 vertical = false,
+                label = "boundary regions",
             )
         end
     end


### PR DESCRIPTION
After using `gridplot` with `GLMakie` for a while I asked myself why
- the colorbars display a wrong number of regions (see https://github.com/WIAS-PDELib/GridVisualizeTools.jl/pull/9)
- the bars are not labeled with a title.

I think the users may use the grid plot to determine the indices and total number of cell/boundary regions by looking at the `gridplot`.

With this proposed changes, together with https://github.com/WIAS-PDELib/GridVisualizeTools.jl/pull/9, the result looks like this

![Screenshot_20241118_124857](https://github.com/user-attachments/assets/b4e64649-f68a-4761-9150-0a98c40ce776)
