### PR TITLE
PyPlot: fix label position and annotate color bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [unreleased]
+
+### Added
+
+- `gridplot` with `PyPlot` has now a color bar with annotation `boundary regions`
+
 ## [1.9.0] - 2024-11-25
 
 ### Added


### PR DESCRIPTION
This PR does the following in `gridplot` with `PyPlot`
- display the correct number of boundary regions (needs https://github.com/WIAS-PDELib/GridVisualizeTools.jl/pull/9)
- labels the color bar
- use correct position of the ticks in the color bar
- annotates the color bar with "boundary regions"

Before: 
![image](https://github.com/user-attachments/assets/cce3cc9c-8559-4bc2-963a-25bea3882f6a)

After:
![image](https://github.com/user-attachments/assets/decde0a8-3adb-4dc0-a4c1-3f828f541f43)
