### PR TITLE
Add codespell

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,3 @@
+[codespell]
+ignore-words-list = missings,rcall
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@ Some updates, fixes:
 
 - Prevent PyPlot from normalizing quiver vectors
 
-- Pin CairoMakie vesion due to https://github.com/MakieOrg/Makie.jl/issues/3440
+- Pin CairoMakie version due to https://github.com/MakieOrg/Makie.jl/issues/3440
 
 - Add warnings for functionality not implemented in Plots
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ streamplot(grid, vectorfunction,Plotter=GLMakie)
 
 This works for  1/2/3D grids and either a function  represented by its
 values on  the nodes of the  grid, or a scalar  function of 1, 2  or 3
-variables, respectively. Vector and stream plots are currenly available for 2D only.
+variables, respectively. Vector and stream plots are currently available for 2D only.
 
 The `grid` argument should be an `ExtendableGrid` as defined by the [ExtendableGrids.jl](https://github.com/WIAS-PDELib/ExtendableGrids.jl) package.
 Instead of `grid`, the following arguments can be passed in order to describe a grid (which then is internally created on-the-fly):

--- a/examples/plotting.jl
+++ b/examples/plotting.jl
@@ -8,7 +8,7 @@
 #  `WGLMakie` and `CairoMakie` work in principle but in the moment don't deliver
 #  all necessary functionality. For `Plots` we miss the possibility to work with triangle meshes (this is under development, though)
 # 
-# Also supported is [`VTKView`](https://github.com/j-fu/VTKView.jl)  which is exeprimental and works only on linux.
+# Also supported is [`VTKView`](https://github.com/j-fu/VTKView.jl)  which is experimental and works only on linux.
 #
 #
 # ## Grid plots

--- a/src/common.jl
+++ b/src/common.jl
@@ -305,7 +305,7 @@ function vectorsample(grid::ExtendableGrid{Tv, Ti}, v;
 
                     # Check positivity of bc coordinates with some slack for
                     # round-off errors. Therefore a point may be found in two
-                    # neigboring triangles. Constraining points to the raster ensures
+                    # neighboring triangles. Constraining points to the raster ensures
                     # that only the last of them is taken.
                     if all(x -> x > -tol, λ)
                         # Interpolate vector value

--- a/src/dispatch.jl
+++ b/src/dispatch.jl
@@ -202,7 +202,7 @@ vis=GridVisualizer(Plotter=PyPlot, layout=(2,2)
 ...plot!(vis[1,2], ...)
 ```
 
-A `...plot`  command just implicitely creates a plot context:
+A `...plot`  command just implicitly creates a plot context:
 
 ```julia
 gridplot(grid, Plotter=PyPlot) 
@@ -329,7 +329,7 @@ function default_plot_kwargs()
                                            :offset => Pair(:default, "Offset of quiver grid"),
                                            :vscale => Pair(1.0, "Vector field scale for quiver grid"),
                                            :vconstant => Pair(false, "Set all arrow length constant in vector plot"),
-                                           :vnormalize => Pair(true, "Normalize vector field befor scaling"),
+                                           :vnormalize => Pair(true, "Normalize vector field before scaling"),
                                            :interior => Pair(true, "3D plot interior of grid"),
                                            :xplanes => Pair([prevfloat(Inf)], "3D x plane positions or number thereof"),
                                            :yplanes => Pair([prevfloat(Inf)], "3D y plane positions or number thereof"),
@@ -843,7 +843,7 @@ end
 """
 $(TYPEDSIGNATURES)
 
-Finish and show plot. Same as setting `:reveal=true` or `:show=true` in last plot statment
+Finish and show plot. Same as setting `:reveal=true` or `:show=true` in last plot statement
 for a context.
 """
 reveal(visualizer::GridVisualizer) = reveal(visualizer, plottertype(visualizer.Plotter))

--- a/src/makie.jl
+++ b/src/makie.jl
@@ -399,7 +399,7 @@ function scalarplot!(ctx, TP::Type{MakieType}, ::Type{Val{1}}, grids, parentgrid
                                 markersize = ctx[:markersize],)
             end
 
-            # Draw  dummy line with marker on top ot the first
+            # Draw  dummy line with marker on top of the first
             # marker position already drawn in order to
             # get the proper legend entry
             if ctx[:label] != ""
@@ -511,12 +511,12 @@ function makescene_grid(ctx)
         GL[2, 1] = XMakie.Colorbar(ctx[:figure];
                                    colormap = XMakie.cgrad(ctx[:cmap]; categorical = true),
                                    limits = (1, ncol),
-                                   heigth = 15,
+                                   height = 15,
                                    vertical = false,)
         GL[3, 1] = XMakie.Colorbar(ctx[:figure];
                                    colormap = XMakie.cgrad(ctx[:bcmap]; categorical = true),
                                    limits = (1, nbcol),
-                                   heigth = 15,
+                                   height = 15,
                                    vertical = false,)
     end
     GL

--- a/src/plots.jl
+++ b/src/plots.jl
@@ -3,10 +3,10 @@
 reveal=true anstelle von show=true ?
 reveal(p)
 
-2D Arrays in 1D plot wie in plts: Label als array, color als array.
-Das geht auch einfach in Makie
+2D Arrays in 1D plot as in plts: Label as array, color as array.
+This also works in Makie
 
-pass=(...): kwargs für plotter
+pass=(...): kwargs for plotter
 =#
 
 initialize!(p, ::Type{PlotsType}) = nothing


### PR DESCRIPTION
This adds support for [codespell](https://github.com/codespell-project/codespell),
which is a spellchecker based on a dictionary of common typos.

The first commit adds a `.codespellrc` configuration file,
which makes codespell ignore two common typos:
- `rcall` for `recall`
- `missings` for missing 
as both are Julia package names we use throughout pdelib.

The second commit amends the legitimate typos codespell has found.
