### PR TITLE
Cap number of cmaps in Pyplot to 2

### DIFF
--- a/src/pyplot.jl
+++ b/src/pyplot.jl
@@ -179,7 +179,7 @@ function gridplot!(ctx, TP::Type{PyPlotType}, ::Type{Val{1}}, grid)
         ax.plot([x2, x2], [-h, h]; linewidth = ctx[:linewidth], color = "k", label = "")
     end
 
-    cmap = bregion_cmap(nbfaceregions)
+    cmap = bregion_cmap(max(nbfaceregions, 2))
     for ibface in 1:num_bfaces(grid)
         ireg = bfaceregions[ibface]
         if ireg > 0


### PR DESCRIPTION
As previously done in PR #41 this adds a `max(2,...)` to cmap in pyplot.