### PR TITLE
Fix Pyplot, Add unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 - unit test for undocumented names
 
+- Unit test for `PyPlot` and `PlutoVista`
+
 ### Removed
 
 - dangling exported function `backend!`

--- a/Project.toml
+++ b/Project.toml
@@ -50,3 +50,14 @@ Printf = "1.6"
 PyPlot = "2"
 StaticArrays = "1"
 julia = "1.9"
+
+[extras]
+CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
+ExtendableGrids = "cfc395e8-590f-11e8-1f13-43a2532b2fa8"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+PlutoVista = "646e1f28-b900-46d7-9d87-d554eb38a413"
+PyPlot = "d330b81b-6aea-500a-939a-2ce795aea3ee"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["CairoMakie", "ExtendableGrids", "Pkg", "PlutoVista", "PyPlot", "Test"]

--- a/src/pyplot.jl
+++ b/src/pyplot.jl
@@ -242,10 +242,17 @@ function gridplot!(ctx, TP::Type{PyPlotType}, ::Type{Val{2}}, grid)
 
     cell_colors = cellcolors(grid, ctx[:cellcoloring])
 
+    # the first triangle for dummy plot below
+    dummy_triangle = @views tridat[3][1, :]
+
+    # the corresponding coordinates (add +1 for Python → Julia)
+    dummy_coords_x = [ tridat[1][i + 1] for i in dummy_triangle ]
+    dummy_coords_y = [ tridat[2][i + 1] for i in dummy_triangle ]
+
     # dummy plot to get a correct color bar for the boundary data
     bcdata = ax.tripcolor(
-        tridat[1][1:3], tridat[2][1:3]; # extract a single point from the original triangulation
-        facecolors = cell_colors[1:1],  # only one triangle!
+        dummy_coords_x, dummy_coords_y, dummy_triangle; # use the dummy triangle
+        facecolors = cell_colors[1:1],                  # only one triangle!
         cmap = PyPlot.ColorMap(bcmap, length(bcmap)),
         vmin = 0.5,
         vmax = length(bcmap) + 0.5,

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,6 +1,0 @@
-[deps]
-CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
-ExtendableGrids = "cfc395e8-590f-11e8-1f13-43a2532b2fa8"
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-Pluto = "c3e4b0f8-55cb-11ea-2926-15256bba5781"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,12 +1,28 @@
 using Test, ExtendableGrids, GridVisualize, Pkg
-import CairoMakie
+
+import CairoMakie, PyPlot, PlutoVista
+
 CairoMakie.activate!(; type = "svg", visible = false)
 
 plotting = joinpath(@__DIR__, "..", "examples", "plotting.jl")
 include(plotting)
 include("../docs/makeplots.jl")
-@testset "makeplots - CairoMakie" begin
-    makeplots(mktempdir(); Plotter = CairoMakie, extension = ".svg")
+
+for Plotter in [CairoMakie]
+    @eval begin
+        @testset "makeplots - $(nameof($Plotter))" begin
+            makeplots(mktempdir(); Plotter = $Plotter, extension = ".svg")
+        end
+    end
+end
+
+# Some Plotters cannot perform the `makeplots` run, only try a `multiscene`
+for Plotter in [PyPlot, PlutoVista]
+    @eval begin
+        @testset "plotting_multiscene - $(nameof($Plotter))" begin
+            @test plotting_multiscene(Plotter = $Plotter) !== nothing
+        end
+    end
 end
 
 


### PR DESCRIPTION
This should fix the issue from comment https://github.com/WIAS-PDELib/GridVisualize.jl/pull/39#issuecomment-2503998781

I still plot a dummy triangle, but now it is explicitly constructed as the first triangle of the triangulation.

Also, CI is extended by a test for PyPlot and PlutoVista, as requested in #53. The new test would have caught the issue from before.
I hope the tests run headless, at least they did on my machine :)

I used the chance to merge the `Project.toml` from the test folder into the main one.