### PR TITLE
Disable `julia-actions/cache` for now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,16 +30,18 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v2
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
+      # # disabled for now, see  https://github.com/JuliaPy/Conda.jl/issues/251
+      # # Conda's installation of Python was "sometimes" not found
+      # - uses: julia-actions/cache@v2
+      #   env:
+      #     cache-name: cache-artifacts
+      #   with:
+      #     path: ~/.julia/artifacts
+      #     key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+      #     restore-keys: |
+      #       ${{ runner.os }}-test-${{ env.cache-name }}-
+      #       ${{ runner.os }}-test-
+      #       ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@v1
         env:
           PYTHON: ""


### PR DESCRIPTION
A deep investigation of the _sometimes_ failing CI tests caused by missing `libpython` let to `julia-actions/cache`.

`Conda.jl` uses `.julia/conda` to keep track of the installed files, see https://github.com/JuliaPy/Conda.jl/issues/251
This does not play well with the `cache` action.

Whenever this issue is fixed, the `cache` should be activated again.