### PR TITLE
Remove PlutoVista from deps

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,6 @@ IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Observables = "510215fc-4207-5dde-b226-833fc4488ee2"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
-PlutoVista = "646e1f28-b900-46d7-9d87-d554eb38a413"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 


### PR DESCRIPTION
This just did sneak in for unknown reason.

Generally, the Idea of GridVisualize is that it should not depend directly on any graphics package.
