### PR TITLE
Split the page 'Examples' into two pages

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -24,10 +24,8 @@ function mkdocs()
         pages = [
             "Home" => "index.md",
             "Public API" => "api.md",
-            "Examples" => [
-                "Plotting examples" => generated_examples,
-                "Pluto notebooks" => notebook_examples,
-            ],
+            "Examples" => generated_examples,
+            "Pluto notebooks" => notebook_examples,
             "Private API" => "privapi.md",
             "Contributing" => "contributing.md",
         ]


### PR DESCRIPTION
In Documentation: Split the 'Examples' page into 'Examples' for plotting and 'Pluto Notebooks'.
Closes #72