### PR TITLE
Remove Default Argument Overrides in Plot Dispatches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Changelog
+## [1.14.1] - 2025-06-16
+- Removed automatic overrides of user-supplied keywords `clear` , `show`, and `reveal` in `scalarplot!`, `vectorplot!`, `streamplot!`, and `customplot!`.
+- Included `CHANGELOG.md` in docs.
+
 ## [1.14.0] - 2025-06-13
 - Move plotting code to extensions
-- Add `plot_triangulateio` method moved from [Triangulate.jl](https://github.com/JuliaGeometry/Triangulate.jl
+- Add `plot_triangulateio` method moved from [Triangulate.jl](https://github.com/JuliaGeometry/Triangulate.jl)
 
 ## [1.13.0] - 2025-06-12
 - Bump makie dependency

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GridVisualize"
 uuid = "5eed8a63-0fb0-45eb-886d-8d5a387d12b8"
-version = "1.14.0"
+version = "1.14.1"
 authors = ["Juergen Fuhrmann <juergen.fuhrmann@wias-berlin.de>", "Patrick Jaap <patrick.jaap@wias-berlin.de>"]
 
 [deps]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -42,6 +42,7 @@ function mkdocs()
         repo = "https://github.com/WIAS-PDELib/GridVisualize.jl",
         pages = [
             "Home" => "index.md",
+            "Changelog" => "changes.md",
             "Public API" => "api.md",
             "Examples" => generated_examples,
             "Pluto notebooks" => notebook_examples,

--- a/docs/src/changes.md
+++ b/docs/src/changes.md
@@ -1,0 +1,4 @@
+````@eval
+using Markdown
+Markdown.parse(read("../../CHANGELOG.md",String))
+````

--- a/src/dispatch.jl
+++ b/src/dispatch.jl
@@ -528,10 +528,9 @@ If instead of the grid, coordinate vectors are given, a temporary grid is create
 Keyword arguments: see [`available_kwargs`](@ref)
 """
 function scalarplot!(ctx::SubVisualizer, grid::ExtendableGrid, func; kwargs...)
-    _update_context!(ctx, Dict(:clear => true, :show => false, :reveal => false))
     _update_context!(ctx, kwargs)
 
-    # call a specialized function if the user want to plot only a dim-1 slice of the data
+    # call a specialized function if the user wants to plot only a dim-1 slice of the data
     if haskey(ctx, :slice) && ctx[:slice] !== nothing
         return slice_plot!(ctx, Val{dim_space(grid)}, grid, func)
     else
@@ -544,7 +543,7 @@ $(TYPEDSIGNATURES)
 
 Plot node vectors on subgrids of parent grid as P1 FEM function on the triangulation into subplot in the visualizer.
 If `[i,j]` is omitted, `[1,1]` is assumed.
-eyword arguments: see [`available_kwargs`](@ref)
+Keyword arguments: see [`available_kwargs`](@ref)
 """
 function scalarplot!(
         ctx::SubVisualizer,
@@ -553,7 +552,6 @@ function scalarplot!(
         funcs::AbstractVector;
         kwargs...,
     ) where {Tv, Ti}
-    _update_context!(ctx, Dict(:clear => true, :show => false, :reveal => false))
     _update_context!(ctx, kwargs)
     if length(grids) != length(funcs)
         error("number of subgrids: $(length(grids)) and number of functions: $(length(funcs)) not equal")
@@ -725,7 +723,6 @@ $(TYPEDSIGNATURES)
 Plot piecewise linear vector field  as quiver plot.
 """
 function vectorplot!(ctx::SubVisualizer, grid::ExtendableGrid, func; kwargs...)
-    _update_context!(ctx, Dict(:clear => true, :show => false, :reveal => false))
     _update_context!(ctx, kwargs)
     if ctx[:spacing] != nothing
         @warn "`spacing` has been removed from keyword arguments, use `rasterpoints` to control spacing"
@@ -822,7 +819,6 @@ Plot piecewise linear vector field  as stream plot.
 (2D pyplot only)
 """
 function streamplot!(ctx::SubVisualizer, grid::ExtendableGrid, func; kwargs...)
-    _update_context!(ctx, Dict(:clear => true, :show => false, :reveal => false))
     _update_context!(ctx, kwargs)
     if ctx[:spacing] != nothing
         @warn "`spacing` has been removed from keyword arguments, use `rasterpoints` to control spacing"
@@ -907,7 +903,6 @@ end
 ###################################################################################
 "$(TYPEDSIGNATURES)"
 function customplot!(ctx::SubVisualizer, func; kwargs...)
-    _update_context!(ctx, Dict(:clear => true, :show => false, :reveal => false))
     _update_context!(ctx, kwargs)
     if ctx[:spacing] != nothing
         @warn "`spacing` has been removed from keyword arguments, use `rasterpoints` to control spacing"

--- a/src/slice_plots.jl
+++ b/src/slice_plots.jl
@@ -254,7 +254,6 @@ function slice_plot!(ctx, ::Type{Val{3}}, grid, values)
         @views grid_2d[CellNodes][:, it] .= t
     end
 
-    # kwargs are merged into ctx
     return scalarplot!(ctx, grid_2d, new_values)
 end
 
@@ -331,6 +330,5 @@ function slice_plot!(ctx, ::Type{Val{2}}, grid, values)
     grid_1d[Coordinates] = @views grid_1d[Coordinates][:, p]
     new_values = new_values[p]
 
-    # kwargs are merged into ctx
     return scalarplot!(ctx, grid_1d, new_values)
 end

--- a/src/slice_plots.jl
+++ b/src/slice_plots.jl
@@ -255,7 +255,7 @@ function slice_plot!(ctx, ::Type{Val{3}}, grid, values)
     end
 
     # kwargs are merged into ctx
-    return scalarplot!(ctx, grid_2d, new_values; show = ctx[:show])
+    return scalarplot!(ctx, grid_2d, new_values)
 end
 
 
@@ -332,5 +332,5 @@ function slice_plot!(ctx, ::Type{Val{2}}, grid, values)
     new_values = new_values[p]
 
     # kwargs are merged into ctx
-    return scalarplot!(ctx, grid_1d, new_values; show = ctx[:show])
+    return scalarplot!(ctx, grid_1d, new_values)
 end


### PR DESCRIPTION
I've been playing around with the newly added slice plots. To compare two solutions within the same slice, I want to add two slice plots into one associated subvisualizer like so:
```julia
vis = GridVisualizer(; Plotter = PyPlot)
scalarplot!(vis, grid, sol1, slice = ..., clear = false)
scalarplot!(vis, grid, sol2, slice = ..., clear = false)
reveal(vis)
```
I expect to see slice plots for `sol1` and `sol2` to be shown in the same window, but only get to see the last one. 

This is because the `scalarplot!` dispatch resets the `clear` option to `false` every time it is called unless the associated `kwargs` say otherwise.

I've found similar behaviour in a couple of other dispatch calls, but notably not in `gridplot`.
Since I didn't notice any problems with just getting rid of those overrides, I'd propose to remove them (I'm not clear why they're there to begin with since fresh `GridVisualizer`s are instantiated with exactly these overrides as default plotting contexts). Does anyone see any problems with that?
@j-fu @pjaap 