### PR TITLE
Fix 1D legend entries in `gridplot`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v5.0.0
+  rev: v6.0.0
   hooks:
   - id: check-added-large-files
     args: [--maxkb=8192]
@@ -12,11 +12,11 @@ repos:
   - id: no-commit-to-branch
     args: [--branch, main]
 - repo: https://github.com/gitleaks/gitleaks
-  rev: v8.24.2
+  rev: v8.29.0
   hooks:
   - id: gitleaks
 - repo: https://github.com/fredrikekre/runic-pre-commit
-  rev: v1.0.0
+  rev: v2.0.1
   hooks:
   - id: runic
 - repo: https://github.com/codespell-project/codespell

--- a/ext/GridVisualizeMakieExt.jl
+++ b/ext/GridVisualizeMakieExt.jl
@@ -327,7 +327,7 @@ function gridplot!(ctx, TP::Type{MakieType}, ::Type{Val{1}}, grid)
                 map(g -> bregionmesh1d(g, gridscale, i), ctx[:grid]);
                 color = bcmap[i],
                 linewidth = 4,
-                label = "b$(i)",
+                label = "b $(i)",
             )
         end
 

--- a/ext/GridVisualizePlutoVistaExt.jl
+++ b/ext/GridVisualizePlutoVistaExt.jl
@@ -152,7 +152,7 @@ function gridplot!(ctx, TP::Type{PlutoVistaType}, ::Type{Val{1}}, grid)
 
     for icell in 1:num_cells(grid)
         ireg = cellregions[icell]
-        label = crflag[ireg] ? "c$(ireg)" : ""
+        label = crflag[ireg] ? "c $(ireg)" : ""
         crflag[ireg] = false
 
         x1 = coord[1, cellnodes[1, icell]]
@@ -189,7 +189,7 @@ function gridplot!(ctx, TP::Type{PlutoVistaType}, ::Type{Val{1}}, grid)
     for ibface in 1:num_bfaces(grid)
         ireg = bfaceregions[ibface]
         if ireg > 0
-            label = brflag[ireg] ? "b$(ireg)" : ""
+            label = brflag[ireg] ? "b $(ireg)" : ""
             brflag[ireg] = false
             x1 = coord[1, bfacenodes[1, ibface]]
             PlutoVista.plot!(

--- a/ext/GridVisualizePyPlotExt.jl
+++ b/ext/GridVisualizePyPlotExt.jl
@@ -168,7 +168,7 @@ function gridplot!(ctx, TP::Type{PyPlotType}, ::Type{Val{1}}, grid)
 
     for icell in 1:num_cells(grid)
         ireg = cellregions[icell]
-        label = crflag[ireg] ? "c$(ireg)" : ""
+        label = crflag[ireg] ? "c $(ireg)" : ""
         crflag[ireg] = false
 
         x1 = coord[1, cellnodes[1, icell]] * gridscale
@@ -188,7 +188,7 @@ function gridplot!(ctx, TP::Type{PyPlotType}, ::Type{Val{1}}, grid)
     for ibface in 1:num_bfaces(grid)
         ireg = bfaceregions[ibface]
         if ireg > 0
-            label = brflag[ireg] ? "b$(ireg)" : ""
+            label = brflag[ireg] ? "b $(ireg)" : ""
             brflag[ireg] = false
             x1 = coord[1, bfacenodes[1, ibface]] * ctx[:gridscale]
             ax.plot(


### PR DESCRIPTION
There is an inconsistency between no spaces and one space between boundary and cell regions along the backends.

This PR should unify the behavior to using a single space:

<img width="489" height="383" alt="grafik" src="https://github.com/user-attachments/assets/f4f0d57d-6d5f-40c2-9f2b-f2ba74bf3960" />

Nevertheless, "c 1" etc is not the optimal representation, but I do not have a better idea at hand.