### PR TITLE
Plots.jl + PyPlot.jl: use `display` to show a plot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## [1.16.1] - 2025-12-01
-- `Plots.jl`: fixed missing plots in VSCode by using `display` instead of `Plots.gui`
+- `Plots.jl` and `PyPlot.jl`: fixed missing plots in VSCode by using `display` in `reveal`
 
 ## [1.16.0] - 2025-11-18
 - Add PythonPlot to the backends

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [1.16.1] - 2025-12-01
+- `Plots.jl`: fixed missing plots in VSCode by using `display` instead of `Plots.gui`
+
 ## [1.16.0] - 2025-11-18
 - Add PythonPlot to the backends
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GridVisualize"
 uuid = "5eed8a63-0fb0-45eb-886d-8d5a387d12b8"
 authors = ["Juergen Fuhrmann <juergen.fuhrmann@wias-berlin.de>", "Patrick Jaap <patrick.jaap@wias-berlin.de>"]
-version = "1.16.0"
+version = "1.16.1"
 
 [deps]
 ColorSchemes = "35d6a980-a343-548e-a6ea-1d62b119f2f4"

--- a/ext/GridVisualizePlotsExt.jl
+++ b/ext/GridVisualizePlotsExt.jl
@@ -46,7 +46,7 @@ function reveal(p::GridVisualizer, ::Type{PlotsType})
     if haskey(p.context, :videostream)
         return Plots.frame(p.context[:videostream], plt)
     else
-        Plots.gui(plt)
+        display(plt)
         return plt
     end
 end

--- a/src/pycommon.jl
+++ b/src/pycommon.jl
@@ -36,7 +36,10 @@ function reveal(p::GridVisualizer, ::Type{T}) where {T <: AbstractPythonPlotterT
         p.Plotter.draw()
         sleep(1.0e-3)
     end
-    return p.Plotter.gcf()
+    current_figure = p.Plotter.gcf()
+    display(current_figure)
+
+    return current_figure
 end
 
 function reveal(ctx::SubVisualizer, TP::Type{T}) where {T <: AbstractPythonPlotterType}


### PR DESCRIPTION
With this change plots are shown both from Terminal/REPL (in a separate window) and in VSCode (in the plotting tab).

@j-fu Was there a special reason for the `Plots.gui`? 

From the [docs](https://docs.juliaplots.org/stable/api/#Base.Multimedia.display) of `display`: "Display x using the topmost applicable display in the display stack, typically using the richest supported multimedia output for x"